### PR TITLE
add plot.title to element_marquee() example

### DIFF
--- a/R/element_marquee.R
+++ b/R/element_marquee.R
@@ -42,7 +42,7 @@
 #'   geom_point(aes(mpg, disp)) +
 #'   labs(title = "A {.red *marquee*} title\n* Look at this bullet list\n\n* great, huh?") +
 #'   theme_gray(base_size = 6) +
-#'   theme(title = element_marquee())
+#'   theme(plot.title = element_marquee())
 #'
 #' plot(p)
 #'
@@ -54,7 +54,7 @@
 #' ![](p)
 #'
 #' What more could you _possibly_ want?") +
-#'   theme(title = element_marquee())
+#'   theme(plot.title = element_marquee())
 #'
 element_marquee <- function(
   family = NULL,


### PR DESCRIPTION
As noted in #97 these examples should use `plot.title` and not only `title`